### PR TITLE
Add security headers to protect JS

### DIFF
--- a/system_proyect/system_proyect/settings.py
+++ b/system_proyect/system_proyect/settings.py
@@ -34,6 +34,13 @@ CSRF_TRUSTED_ORIGINS = [
     'https://192.168.10.6:437',
 ]
 
+# Reforzar cabeceras de seguridad para proteger el contenido JavaScript
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_BROWSER_XSS_FILTER = True
+X_FRAME_OPTIONS = 'DENY'
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+
 # ─────────────────────────────────────────────────────────────
 # 4. APLICACIONES INSTALADAS
 # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- set browser security headers in `settings.py`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6841b9f6f59c8331b82673df17f6773f