### PR TITLE
Fix logout URL escaping

### DIFF
--- a/system_proyect/core/middleware.py
+++ b/system_proyect/core/middleware.py
@@ -19,7 +19,7 @@ class GlobalScriptMiddleware:
             script = (
                 f"<script>var GLOBAL_USERNAME='{escapejs(username)}';"
                 f"var SHOW_WELCOME={str(show_welcome).lower()};"
-                f"var LOGOUT_URL='{logout_url}';</script>"
+                f"var LOGOUT_URL='{escapejs(logout_url)}';</script>"
                 f"<script src='/static/accounts/js/global.js' defer></script>"
             )
 


### PR DESCRIPTION
## Summary
- escape `logout_url` when constructing global script in middleware

## Testing
- `pytest -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685d845c6bc08331b6741ee5f23a8c77