### PR TITLE
Fix success messages to redirect once

### DIFF
--- a/system_proyect/inventario/templates/inventario/inventario_registros.html
+++ b/system_proyect/inventario/templates/inventario/inventario_registros.html
@@ -19,6 +19,14 @@
 
   <div class="container py-4">
     <h2 class="text-center mb-4">Todos los Registros de Inventario</h2>
+    {% if messages %}
+      {% for message in messages %}
+        <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
+          {{ message }}
+          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
+        </div>
+      {% endfor %}
+    {% endif %}
     <div class="table-responsive bg-white p-3 rounded shadow-sm">
       <table id="registros-table" class="table table-striped table-bordered align-middle mb-0">
         <thead class="table-light">

--- a/system_proyect/tickets/templates/tickets/submit_ticket.html
+++ b/system_proyect/tickets/templates/tickets/submit_ticket.html
@@ -92,7 +92,8 @@
                 method: 'POST',
                 body: formData,
                 headers: {
-                    'X-CSRFToken': '{{ csrf_token }}'
+                    'X-CSRFToken': '{{ csrf_token }}',
+                    'X-Requested-With': 'XMLHttpRequest'
                 }
             })
             .then(response => response.json())

--- a/system_proyect/tickets/views.py
+++ b/system_proyect/tickets/views.py
@@ -96,9 +96,11 @@ def submit_ticket(request):
                 )
                 send_email_async(subject_user, message_user, [ticket.email])
 
-                # Mensaje de éxito en el navegador
+                if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+                    return JsonResponse({'message': f'Ticket #{ticket.ticket_id} creado exitosamente'}, status=201)
+
                 messages.success(request, f'Ticket #{ticket.ticket_id} creado exitosamente.')
-                return JsonResponse({'message': f'Ticket #{ticket.ticket_id} creado exitosamente'}, status=201)
+                return redirect('success')
 
             else:
                 # Manejo de errores en el formulario


### PR DESCRIPTION
## Summary
- show Bootstrap alerts above inventory registry table
- redirect after ticket creation success to avoid duplicate form resubmissions

## Testing
- `python system_proyect/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6890dbcd31648331823735287eb8106c